### PR TITLE
Improve IndexArray

### DIFF
--- a/core/3d/CCBundle3DData.h
+++ b/core/3d/CCBundle3DData.h
@@ -137,18 +137,18 @@ public:
     template <typename _Ty = uint16_t>
     const _Ty* begin() const
     {
-        return (const Ty*)_buffer.begin();
+        return (const _Ty*)_buffer.begin();
     }
     template <typename _Ty = uint16_t>
     _Ty* begin()
     {
-        return (Ty*)_buffer.begin();
+        return (_Ty*)_buffer.begin();
     }
 
     template <typename _Ty = uint16_t>
     const _Ty* end() const
     {
-        return (const Ty*)_buffer.end();
+        return (const _Ty*)_buffer.end();
     }
     template <typename _Ty = uint16_t>
     _Ty* end()

--- a/core/3d/CCBundle3DData.h
+++ b/core/3d/CCBundle3DData.h
@@ -184,19 +184,19 @@ public:
         return (const _Ty&)_buffer[idx * sizeof(_Ty)];
     }
 
-    template <typename _Ty = uint16_t, std::enable_if_t<is_index_format_type_v<_Ty>, int> = 0>
-    _Ty& operator[](size_t idx)
-    {
-        assert(sizeof(_Ty) == _stride);
-        return (_Ty&)_buffer[idx * sizeof(_Ty)];
-    }
+    //template <typename _Ty = uint16_t, std::enable_if_t<is_index_format_type_v<_Ty>, int> = 0>
+    //_Ty& operator[](size_t idx)
+    //{
+    //    assert(sizeof(_Ty) == _stride);
+    //    return (_Ty&)_buffer[idx * sizeof(_Ty)];
+    //}
 
-    template <typename _Ty = uint16_t, std::enable_if_t<is_index_format_type_v<_Ty>, int> = 0>
-    const _Ty& operator[](size_t idx) const
-    {
-        assert(sizeof(_Ty) == _stride);
-        return (const _Ty&)_buffer[idx * sizeof(_Ty)];
-    }
+    //template <typename _Ty = uint16_t, std::enable_if_t<is_index_format_type_v<_Ty>, int> = 0>
+    //const _Ty& operator[](size_t idx) const
+    //{
+    //    assert(sizeof(_Ty) == _stride);
+    //    return (const _Ty&)_buffer[idx * sizeof(_Ty)];
+    //}
 
     uint8_t* data() noexcept { return _buffer.data(); }
     const uint8_t* data() const noexcept { return _buffer.data(); }

--- a/core/3d/CCBundle3DData.h
+++ b/core/3d/CCBundle3DData.h
@@ -1,6 +1,7 @@
 /****************************************************************************
  Copyright (c) 2014-2016 Chukong Technologies Inc.
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2022 Bytedance Inc.
 
  https://adxeproject.github.io/
 
@@ -43,8 +44,8 @@
 
 NS_CC_BEGIN
 
-using uint16_index_format  = std::integral_constant<int, 1>;
-using uint32_index_format  = std::integral_constant<int, 2>;
+using uint16_index_format = std::integral_constant<int, 1>;
+using uint32_index_format = std::integral_constant<int, 2>;
 
 class IndexArray
 {
@@ -59,10 +60,10 @@ public:
     IndexArray(backend::IndexFormat indexFormat) : _stride(formatToStride(indexFormat)) {}
 
     IndexArray(std::initializer_list<uint16_t> rhs, uint16_index_format /*U_SHORT*/)
-        : _stride(formatToStride(backend::IndexFormat::U_SHORT)), _buffer(rhs)
+        : _stride(sizeof(uint16_t)), _buffer(rhs)
     {}
     IndexArray(std::initializer_list<uint32_t> rhs, uint32_index_format /*U_INT*/)
-        : _stride(formatToStride(backend::IndexFormat::U_INT)), _buffer(rhs)
+        : _stride(sizeof(uint32_t)), _buffer(rhs)
     {}
 
     IndexArray(const IndexArray& rhs) : _stride(rhs._stride), _buffer(rhs._buffer) {}
@@ -86,8 +87,18 @@ public:
         _buffer.swap(rhs._buffer);
     }
 
+    /** Returns the format of the index array. */
+    backend::IndexFormat format() const { return strideToFormat(_stride); }
+
     /** Clears the internal byte buffer. */
     void clear() { _buffer.clear(); }
+
+    /** Clears the internal byte buffer and sets the format specified. */
+    void clear(backend::IndexFormat format)
+    {
+        clear();
+        _stride = formatToStride(format);
+    }
 
     /** Pushes back a value. */
     void push_back(uint32_t val)
@@ -96,34 +107,81 @@ public:
         _buffer.append_n((uint8_t*)&val, _stride);
     }
 
-    /** Inserts a list containing unsigned short (uint16_t) data. */
-    void insert(size_t offset, std::initializer_list<uint16_t> ilist, uint16_index_format /*U_SHORT*/)
+    /** Inserts a list containing unsigned int (uint16_t/uint32_t) data. */
+    template <typename _Ty = uint16_t>
+    void insert(_Ty* position, std::initializer_list<_Ty> ilist)
     {
-        assert(_stride == 2);
-        binsert(offset * _stride, ilist.begin(), ilist.end());
+        insert(position, ilist.begin(), ilist.end());
     }
 
-    /** Inserts a list containing unsigned int (uint32_t) data. */
-    void insert(size_t offset, std::initializer_list<uint32_t> ilist, uint32_index_format /*U_INT*/)
+    template <typename _Ty = uint16_t>
+    void insert(_Ty* position, _Ty* first, _Ty* last)
     {
-        assert(_stride == 4);
-        binsert(offset * _stride, ilist.begin(), ilist.end());
+        assert(_stride == sizeof(_Ty));
+        binsert(position, first, last);
+    }
+
+    template <typename _Ty = uint16_t>
+    void insert(size_t offset, std::initializer_list<_Ty> ilist)
+    {
+        assert(_stride == sizeof(_Ty));
+        binsert(begin<_Ty>() + offset, ilist.begin(), ilist.end());
     }
 
     /** Inserts range data based on an offset in bytes. */
-    void binsert(size_t offset, const void* first, const void* last)
+    void binsert(uint8_t* position, const void* first, const void* last)
     {
-        _buffer.insert(offset, (const uint8_t*)first, (const uint8_t*)last);
+        _buffer.insert(position, (const uint8_t*)first, (const uint8_t*)last);
     }
 
-    template <typename _Ty>
+    template <typename _Ty = uint16_t>
+    const _Ty* begin() const
+    {
+        return (const Ty*)_buffer.begin();
+    }
+    template <typename _Ty = uint16_t>
+    _Ty* begin()
+    {
+        return (Ty*)_buffer.begin();
+    }
+
+    template <typename _Ty = uint16_t>
+    const _Ty* end() const
+    {
+        return (const Ty*)_buffer.end();
+    }
+    template <typename _Ty = uint16_t>
+    _Ty* end()
+    {
+        return (_Ty*)_buffer.end();
+    }
+
+    template <typename _Ty = uint16_t>
+    _Ty* erase(_Ty* position)
+    {
+        return (_Ty*)_buffer.erase((uint8_t*)position);
+    }
+
+    template <typename _Ty = uint16_t>
+    _Ty* erase(_Ty* first, _Ty* last)
+    {
+        return (_Ty*)_buffer.erase((uint8_t*)first, (uint8_t*)last);
+    }
+
+    template <typename _Ty = uint16_t>
     _Ty& at(size_t idx)
     {
         assert(sizeof(_Ty) == _stride);
-        if (idx < this->size())
-            return (_Ty&)_buffer[idx * sizeof(_Ty)];
-        throw std::out_of_range("IndexArray: out of range!");
+        return (_Ty&)_buffer[idx * sizeof(_Ty)];
     }
+
+    //uint32_t operator[](size_t idx)
+    //{
+    //    assert(_stride == 2 || _stride == 4);
+    //    uint32_t val = 0;
+    //    memcpy(&val, &_buffer[idx * _stride], _stride);
+    //    return val;
+    //}
 
     uint8_t* data() noexcept { return _buffer.data(); }
     const uint8_t* data() const noexcept { return _buffer.data(); }
@@ -140,16 +198,6 @@ public:
 
     /** Returns true if the container is empty. Otherwise, false. */
     bool empty() const { return _buffer.empty(); }
-
-    /** Returns the format of the index array. */
-    backend::IndexFormat format() const { return strideToFormat(_stride); }
-
-    /** Clears the internal byte buffer and sets the format specified. */
-    void clear(backend::IndexFormat format)
-    {
-        clear();
-        _stride = formatToStride(format);
-    }
 
     template <typename _Fty>
     void for_each(_Fty cb) const
@@ -254,7 +302,6 @@ struct NodeDatas
         nodes.clear();
     }
 };
-
 
 /**mesh data
  * @js NA

--- a/core/3d/CCBundle3DData.h
+++ b/core/3d/CCBundle3DData.h
@@ -184,20 +184,6 @@ public:
         return (const _Ty&)_buffer[idx * sizeof(_Ty)];
     }
 
-    //template <typename _Ty = uint16_t, std::enable_if_t<is_index_format_type_v<_Ty>, int> = 0>
-    //_Ty& operator[](size_t idx)
-    //{
-    //    assert(sizeof(_Ty) == _stride);
-    //    return (_Ty&)_buffer[idx * sizeof(_Ty)];
-    //}
-
-    //template <typename _Ty = uint16_t, std::enable_if_t<is_index_format_type_v<_Ty>, int> = 0>
-    //const _Ty& operator[](size_t idx) const
-    //{
-    //    assert(sizeof(_Ty) == _stride);
-    //    return (const _Ty&)_buffer[idx * sizeof(_Ty)];
-    //}
-
     uint8_t* data() noexcept { return _buffer.data(); }
     const uint8_t* data() const noexcept { return _buffer.data(); }
 

--- a/thirdparty/yasio/.clang-format
+++ b/thirdparty/yasio/.clang-format
@@ -6,8 +6,8 @@ Standard: Cpp11
 
 SortIncludes: false
 
-# Keep lines under 160 columns long.
-ColumnLimit: 160
+# Keep lines under 100 columns long.
+ColumnLimit: 100
 
 # Always break before braces
 BreakBeforeBraces: Custom
@@ -52,3 +52,5 @@ KeepEmptyLinesAtTheStartOfBlocks: true
 IndentPPDirectives: AfterHash
 
 AlwaysBreakTemplateDeclarations: Yes
+
+AlignEscapedNewlines: Left

--- a/thirdparty/yasio/detail/byte_buffer.hpp
+++ b/thirdparty/yasio/detail/byte_buffer.hpp
@@ -42,6 +42,7 @@ The byte_buffer concepts:
 #include <type_traits>
 #include <stdexcept>
 #include <initializer_list>
+#include <type_traits>
 #include "yasio/compiler/feature_test.hpp"
 
 namespace yasio
@@ -58,6 +59,9 @@ namespace yasio
                                                         \
   } while (false)
 
+template <bool _Test, class _Ty = void>
+using enable_if_t = typename ::std::enable_if<_Test, _Ty>::type;
+
 struct default_allocator {
   static void* reallocate(void* old_block, size_t /*old_size*/, size_t new_size)
   {
@@ -70,17 +74,23 @@ class basic_byte_buffer {
                 "The basic_byte_buffer only accept type which is char or unsigned char!");
 
 public:
-  using pointer        = _Elem*;
-  using const_pointer  = const _Elem*;
-  using size_type      = size_t;
-  using value_type     = _Elem;
-  using iterator       = _Elem*;
-  using const_iterator = const _Elem*;
+  using pointer         = _Elem*;
+  using const_pointer   = const _Elem*;
+  using reference       = _Elem&;
+  using const_reference = const _Elem&;
+  using size_type       = size_t;
+  using value_type      = _Elem;
+  using iterator        = _Elem*; // byte_buffer only needs transparent iterator
+  using const_iterator  = const _Elem*;
+  using allocator_type  = _Alloc;
   basic_byte_buffer() {}
   explicit basic_byte_buffer(size_t count) { resize(count); }
   basic_byte_buffer(size_t count, std::true_type /*fit*/) { resize_fit(count); }
-  basic_byte_buffer(size_t count, _Elem val) { resize(count, val); }
-  basic_byte_buffer(size_t count, _Elem val, std::true_type /*fit*/) { resize_fit(count, val); }
+  basic_byte_buffer(size_t count, const_reference val) { resize(count, val); }
+  basic_byte_buffer(size_t count, const_reference val, std::true_type /*fit*/)
+  {
+    resize_fit(count, val);
+  }
   template <typename _Iter>
   basic_byte_buffer(_Iter first, _Iter last)
   {
@@ -95,14 +105,14 @@ public:
   basic_byte_buffer(const basic_byte_buffer& rhs, std::true_type /*fit*/)
   {
     assign(rhs, std::true_type{});
-  };
+  }
   basic_byte_buffer(basic_byte_buffer&& rhs) noexcept { assign(std::move(rhs)); }
-  template <typename _Ty>
+  template <typename _Ty, enable_if_t<std::is_integral<_Ty>::value, int> = 0>
   basic_byte_buffer(std::initializer_list<_Ty> rhs)
   {
     assign(rhs);
   }
-  template <typename _Ty>
+  template <typename _Ty, enable_if_t<std::is_integral<_Ty>::value, int> = 0>
   basic_byte_buffer(std::initializer_list<_Ty> rhs, std::true_type /*fit*/)
   {
     assign(rhs, std::true_type{});
@@ -123,7 +133,7 @@ public:
   {
     return this->append(std::begin(rhs), std::end(rhs));
   }
-  basic_byte_buffer& operator+=(const _Elem& rhs)
+  basic_byte_buffer& operator+=(const_reference rhs)
   {
     this->push_back(rhs);
     return *this;
@@ -144,15 +154,15 @@ public:
     _Assign_range(rhs.begin(), rhs.end(), std::true_type{});
   }
   void assign(basic_byte_buffer&& rhs) { _Assign_rv(std::move(rhs)); }
-  template <typename _Ty>
+  template <typename _Ty, enable_if_t<std::is_integral<_Ty>::value, int> = 0>
   void assign(std::initializer_list<_Ty> rhs)
   {
-    _Assign_range((_Elem*)rhs.begin(), (_Elem*)rhs.end());
+    _Assign_range((iterator)rhs.begin(), (iterator)rhs.end());
   }
-  template <typename _Ty>
+  template <typename _Ty, enable_if_t<std::is_integral<_Ty>::value, int> = 0>
   void assign(std::initializer_list<_Ty> rhs, std::true_type /*fit*/)
   {
-    _Assign_range((_Elem*)rhs.begin(), (_Elem*)rhs.end(), std::true_type{});
+    _Assign_range((iterator)rhs.begin(), (iterator)rhs.end(), std::true_type{});
   }
   void swap(basic_byte_buffer& rhs) noexcept
   {
@@ -198,10 +208,10 @@ public:
       std::copy_n(first, count, _Myfirst + old_size);
     }
     else if (count == 1)
-      push_back(static_cast<_Elem>(*first));
+      push_back(static_cast<value_type>(*first));
     return *this;
   }
-  void push_back(_Elem v)
+  void push_back(value_type v)
   {
     resize(this->size() + 1);
     *(_Mylast - 1) = v;
@@ -219,12 +229,12 @@ public:
     _Mylast = std::move(last, _Mylast, first);
     return first;
   }
-  _Elem& front()
+  value_type& front()
   {
     _YASIO_VERIFY_RANGE(_Myfirst < _Mylast, "byte_buffer: out of range!");
     return *_Myfirst;
   }
-  _Elem& back()
+  value_type& back()
   {
     _YASIO_VERIFY_RANGE(_Myfirst < _Mylast, "byte_buffer: out of range!");
     return *(_Mylast - 1);
@@ -241,14 +251,14 @@ public:
   void clear() noexcept { _Mylast = _Myfirst; }
   void shrink_to_fit() { shrink_to_fit(this->size()); }
   bool empty() const noexcept { return _Mylast == _Myfirst; }
-  void resize(size_t new_size, _Elem val)
+  void resize(size_t new_size, const_reference val)
   {
     auto old_size = this->size();
     resize(new_size);
     if (old_size < new_size)
       memset(_Myfirst + old_size, val, new_size - old_size);
   }
-  _Elem* resize(size_t new_size)
+  pointer resize(size_t new_size)
   {
     auto old_cap = this->capacity();
     if (old_cap < new_size)
@@ -256,14 +266,14 @@ public:
     _Mylast = _Myfirst + new_size;
     return _Myfirst;
   }
-  void resize_fit(size_t new_size, _Elem val)
+  void resize_fit(size_t new_size, const_reference val)
   {
     auto old_size = this->size();
     resize_fit(new_size);
     if (old_size < new_size)
       memset(_Myfirst + old_size, val, new_size - old_size);
   }
-  _Elem* resize_fit(size_t new_size)
+  pointer resize_fit(size_t new_size)
   {
     if (this->capacity() < new_size)
       _Reallocate_exactly(new_size);
@@ -285,14 +295,14 @@ public:
       _Mylast = _Myfirst + cur_size;
     }
   }
-  const _Elem& operator[](size_t index) const { return this->at(index); }
-  _Elem& operator[](size_t index) { return this->at(index); }
-  const _Elem& at(size_t index) const
+  const_reference operator[](size_t index) const { return this->at(index); }
+  reference operator[](size_t index) { return this->at(index); }
+  const_reference at(size_t index) const
   {
     _YASIO_VERIFY_RANGE(index < this->size(), "byte_buffer: out of range!");
     return _Myfirst[index];
   }
-  _Elem& at(size_t index)
+  reference at(size_t index)
   {
     _YASIO_VERIFY_RANGE(index < this->size(), "byte_buffer: out of range!");
     return _Myfirst[index];
@@ -302,12 +312,12 @@ public:
     if (ptr)
     {
       shrink_to_fit(0);
-      _Myfirst = (_Elem*)ptr;
+      _Myfirst = (pointer)ptr;
       _Myend = _Mylast = _Myfirst + len;
     }
   }
   template <typename _TSIZE>
-  _Elem* detach(_TSIZE& len) noexcept
+  pointer detach(_TSIZE& len) noexcept
   {
     auto ptr = _Myfirst;
     len      = static_cast<_TSIZE>(this->size());
@@ -337,7 +347,7 @@ private:
   }
   void _Reallocate_exactly(size_t new_cap)
   {
-    auto new_block = (_Elem*)_Alloc::reallocate(_Myfirst, _Myend - _Myfirst, new_cap);
+    auto new_block = (pointer)_Alloc::reallocate(_Myfirst, _Myend - _Myfirst, new_cap);
     if (new_block || 0 == new_cap)
     {
       _Myfirst = new_block;
@@ -346,9 +356,9 @@ private:
     else
       throw std::bad_alloc{};
   }
-  _Elem* _Myfirst = nullptr;
-  _Elem* _Mylast  = nullptr;
-  _Elem* _Myend   = nullptr;
+  pointer _Myfirst = nullptr;
+  pointer _Mylast  = nullptr;
+  pointer _Myend   = nullptr;
 };
 using sbyte_buffer = basic_byte_buffer<char>;
 using byte_buffer  = basic_byte_buffer<unsigned char>;


### PR DESCRIPTION
## Usage

```cpp
    cocos2d::IndexArray indices_u16_a = {(u_short)1, (u_short)2, (u_short)3, (u_short)4, (u_short)5, (u_short)6};
    cocos2d::IndexArray indices_u32_a = {1u, 2u, 3u, 4u, 5u, 6u};
    cocos2d::IndexArray indices_u16_b = cocos2d::ilist_u16_t{1, 2, 3, 4, 5, 6};
    cocos2d::IndexArray indices_u32_b = cocos2d::ilist_u32_t{1, 2, 3, 4, 5, 6};
```