### PR TITLE
IndexArray to stl

### DIFF
--- a/core/3d/CCBundle3DData.h
+++ b/core/3d/CCBundle3DData.h
@@ -103,7 +103,7 @@ public:
     }
 
     /** Pushes back a value. */
-    template <typename _Ty, std::enable_if_t<is_index_format_type_v<_Ty>, int> = 0>
+    template <typename _Ty = uint16_t, std::enable_if_t<is_index_format_type_v<_Ty>, int> = 0>
     void push_back(const _Ty& val)
     {
         assert(_stride == sizeof(_Ty));
@@ -182,6 +182,20 @@ public:
     {
         assert(sizeof(_Ty) == _stride);
         return (const _Ty&)_buffer[idx * sizeof(_Ty)];
+    }
+
+    template <typename _Ty = uint16_t>
+    _Ty& operator[](size_t idx)
+    {
+        assert(sizeof(_Ty) == _stride);
+        return (_Ty&)_buffer[idx * _stride];
+    }
+
+    template <typename _Ty = uint16_t>
+    const _Ty& operator[](size_t idx) const
+    {
+        assert(sizeof(_Ty) == _stride);
+        return (const _Ty&)_buffer[idx * _stride];
     }
 
     uint8_t* data() noexcept { return _buffer.data(); }


### PR DESCRIPTION
Added operator[] for IndexArray to align it to stl container to protect existing code which could use IndexArray with the corresponding api;

Added uint16_t as default template parameter for IndexArray::push_back(...)