### PR TITLE
Expose closeKeyboard() method for EditBox

### DIFF
--- a/core/ui/UIEditBox/UIEditBox.cpp
+++ b/core/ui/UIEditBox/UIEditBox.cpp
@@ -56,6 +56,11 @@ void EditBox::openKeyboard() const
     _editBoxImpl->openKeyboard();
 }
 
+void EditBox::closeKeyboard() const
+{
+    _editBoxImpl->closeKeyboard();
+}
+
 EditBox* EditBox::create(const Vec2& size, std::string_view normalImage, TextureResType texType)
 {
     return EditBox::create(size, normalImage, "", "", texType);

--- a/core/ui/UIEditBox/UIEditBox.h
+++ b/core/ui/UIEditBox/UIEditBox.h
@@ -650,6 +650,7 @@ public:
     void setGlobalZOrder(float globalZOrder) override;
 
     void openKeyboard() const;
+    void closeKeyboard() const;
 
 protected:
     virtual void releaseUpEvent() override;


### PR DESCRIPTION
Exposed the closeKeyboard() function. I couldn't find any tests for openKeyboard() so I didn't any for this. 
Also, is there a need to check if _editBoxImpl is null? 