### PR TITLE
Crashfix in UserDefault

### DIFF
--- a/core/base/CCUserDefault.cpp
+++ b/core/base/CCUserDefault.cpp
@@ -484,7 +484,9 @@ void UserDefault::flush()
         if (obs.length() > _curMapSize)
         {
             _rwmmap->unmap();
-            _curMapSize <<= 1;  // X2
+            while (obs.length() > _curMapSize)
+                _curMapSize <<= 1;  // X2
+                
             posix_fsetsize(_fd, _curMapSize);
             _rwmmap->map(posix_fd2fh(_fd), 0, _curMapSize, error);
         }


### PR DESCRIPTION
Missed an edge case when resizing the memorymapped file in UserDefault that could cause a crash. We never really checked if the new size is enough! 

Not sure if we need an upper-limit here on the size.  @halx99 what do you think?